### PR TITLE
Ds 554 tap salesforce campaign name missing

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -20,12 +20,7 @@ from tap_salesforce.exceptions import (
 
 LOGGER = singer.get_logger()
 
-REQUIRED_CONFIG_KEYS = [
-    "refresh_token",
-    "client_id",
-    "client_secret",
-    "start_date",
-]
+REQUIRED_CONFIG_KEYS = ["refresh_token", "client_id", "client_secret", "start_date"]
 
 CONFIG = {
     "refresh_token": None,
@@ -87,13 +82,7 @@ def main_impl():
             else:
 
                 sync(
-                    sf,
-                    stream,
-                    stream_id,
-                    fields,
-                    replication_key,
-                    start_time,
-                    end_time,
+                    sf, stream, stream_id, fields, replication_key, start_time, end_time
                 )
         except requests.exceptions.HTTPError as err:
 

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -173,9 +173,7 @@ class Salesforce:
         query = f"{select_stm}{from_stm}{where_stm}{order_by_stm}{limit_stm}"
 
         yield from self._paginate(
-            "GET",
-            f"/services/data/{self._API_VERSION}/queryAll/",
-            params={"q": query},
+            "GET", f"/services/data/{self._API_VERSION}/queryAll/", params={"q": query}
         )
 
     def _paginate(

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -14,57 +14,6 @@ from tap_salesforce.exceptions import (
 )
 from tap_salesforce.metrics import Metrics
 
-QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(
-    [
-        "Announcement",
-        "ContentDocumentLink",
-        "CollaborationGroupRecord",
-        "Vote",
-        "IdeaComment",
-        "FieldDefinition",
-        "PlatformAction",
-        "UserEntityAccess",
-        "RelationshipInfo",
-        "ContentFolderMember",
-        "ContentFolderItem",
-        "SearchLayout",
-        "SiteDetail",
-        "EntityParticle",
-        "OwnerChangeOptionInfo",
-        "DataStatistics",
-        "UserFieldAccess",
-        "PicklistValueInfo",
-        "RelationshipDomain",
-        "FlexQueueItem",
-    ]
-)
-
-QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(
-    [
-        "ListViewChartInstance",
-        "FeedLike",
-        "OutgoingEmail",
-        "OutgoingEmailRelation",
-        "FeedSignal",
-        "ActivityHistory",
-        "EmailStatus",
-        "UserRecordAccess",
-        "Name",
-        "AggregateResult",
-        "OpenActivity",
-        "ProcessInstanceHistory",
-        "OwnedContentDocument",
-        "FolderedContentDocument",
-        "FeedTrackedChange",
-        "CombinedAttachment",
-        "AttachedContentDocument",
-        "ContentBody",
-        "NoteAndAttachment",
-        "LookedUpFromActivity",
-        "AttachedContentNote",
-        "QuoteTemplateRichTextData",
-    ]
-)
 
 LOGGER = singer.get_logger()
 
@@ -98,9 +47,6 @@ class Salesforce:
     # CONSTANTS
     _REFRESH_TOKEN_EXPIRATION_PERIOD = 900
     _API_VERSION = "v52.0"
-    _BLACKLISTED_FIELDS = QUERY_RESTRICTED_SALESFORCE_OBJECTS.union(
-        QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS
-    )
 
     def __init__(
         self,
@@ -173,10 +119,7 @@ class Salesforce:
                 for o in sobject["fields"]
             ]
 
-            filtered = filter(
-                lambda f: f.type != "json" and f.name not in self._BLACKLISTED_FIELDS,
-                fields,
-            )
+            filtered = filter(lambda f: f.type != "json", fields)
 
             return {f.name: f for f in filtered}
         except requests.exceptions.HTTPError as err:


### PR DESCRIPTION
In original tap-salesforce. The `QUERY_RESTRICTED_SALESFORCE_OBJECTS and QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS` are used to filter tables(sobject) not fields.
https://github.com/singer-io/tap-salesforce/blob/190c466dc6565f15c5b560b7166684e502307074/tap_salesforce/salesforce/__init__.py#L447
https://github.com/singer-io/tap-salesforce/blob/190c466dc6565f15c5b560b7166684e502307074/tap_salesforce/__init__.py#L134