### PR TITLE
fix: shrink time window if get_record timesout

### DIFF
--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -156,7 +156,7 @@ class Salesforce:
         start_date: datetime,
         end_date: Optional[datetime] = None,
         limit: Optional[int] = None,
-        shrink_window_factor: int = 1,
+        shrink_window_factor: int = 2,
     ) -> Generator[Dict, None, None]:
         field_names = list(fields.keys())
 

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -207,8 +207,8 @@ class Salesforce:
                     table, 
                     fields, 
                     replication_key, 
-                    start_date = start_date + timedelta(seconds=(i-1)*nth), 
-                    end_date = start_date + timedelta(seconds=i*nth), 
+                    start_date = start_date + timedelta(seconds=i*nth), 
+                    end_date = start_date + timedelta(seconds=((i+1)*nth)), 
                     limit=limit,
                     shrink_window_factor=shrink_window_factor+1
                 )

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -164,7 +164,7 @@ class Salesforce:
         from_stm = f"FROM {table} "
 
         if not end_date:
-            end_date = datetime.now()
+            end_date = datetime.utcnow()
 
         if replication_key is not None:
             where_stm = f"WHERE {replication_key} >= {start_date.strftime('%Y-%m-%dT%H:%M:%SZ')} "

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -195,7 +195,7 @@ class Salesforce:
                 "GET", f"/services/data/{self._API_VERSION}/queryAll/", params={"q": query}
             )
         except SalesforceException as e:
-            if e.error_code != 'QUERY_TIMEOUT':
+            if e.code != 'QUERY_TIMEOUT':
                 raise e
 
             nth = (end_date - start_date).total_seconds() / shrink_window_factor

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -1,7 +1,6 @@
 from typing import Optional, Tuple, Generator, Dict
 from datetime import datetime, timedelta
 import re
-from urllib.error import HTTPError
 import backoff
 from pydantic.main import BaseModel
 

--- a/tap_salesforce/exceptions.py
+++ b/tap_salesforce/exceptions.py
@@ -11,3 +11,9 @@ class TapSalesforceQuotaExceededException(TapSalesforceException):
 
 class TapSalesforceOauthException(TapSalesforceException):
     pass
+
+
+class SalesforceException(Exception):
+    def __init__(self, message: str, error_code: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code

--- a/tap_salesforce/exceptions.py
+++ b/tap_salesforce/exceptions.py
@@ -1,6 +1,10 @@
 # pylint: disable=super-init-not-called
 
 
+from typing import Optional
+from requests import Response
+
+
 class TapSalesforceException(Exception):
     pass
 
@@ -17,4 +21,30 @@ class SalesforceException(Exception):
     def __init__(self, message: str, code: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+
+# build_salesforce_exception transforms a generic Response into a SalesforceException if the 
+# response body has a salesforce exception, returns None otherwise
+# salesforce error body looks like:
+# [
+#   {
+#       'message': 'Your query request was running for too long.',
+#       'errorCode': 'QUERY_TIMEOUT',
+#   }
+# ]
+def build_salesforce_exception(resp: Response) -> Optional[SalesforceException]:
+    err_array = resp.json()
+    if not isinstance(err_array, list):
+        return None
+    
+    err_dict = err_array[0]
+
+    if not isinstance(err_dict, dict):
+        return None
+
+    if not err_dict['message'] or not err_dict['errorCode']:
+        return None
+            
+    return SalesforceException(err_dict['message'], err_dict['errorCode'])
 

--- a/tap_salesforce/exceptions.py
+++ b/tap_salesforce/exceptions.py
@@ -18,7 +18,7 @@ class TapSalesforceOauthException(TapSalesforceException):
 
 
 class SalesforceException(Exception):
-    def __init__(self, message: str, code: str) -> None:
+    def __init__(self, message: str, code: Optional[str] = None) -> None:
         super().__init__(message)
         self.code = code
 
@@ -38,13 +38,19 @@ def build_salesforce_exception(resp: Response) -> Optional[SalesforceException]:
     if not isinstance(err_array, list):
         return None
     
+    if len(err_array) < 1:
+        return None
+
     err_dict = err_array[0]
 
     if not isinstance(err_dict, dict):
         return None
 
-    if not err_dict['message'] or not err_dict['errorCode']:
+    msg = err_dict.get('message') 
+    if msg is None:
         return None
-            
-    return SalesforceException(err_dict['message'], err_dict['errorCode'])
+
+    code = err_dict.get('errorCode') 
+
+    return SalesforceException(msg, code)
 

--- a/tap_salesforce/exceptions.py
+++ b/tap_salesforce/exceptions.py
@@ -14,6 +14,7 @@ class TapSalesforceOauthException(TapSalesforceException):
 
 
 class SalesforceException(Exception):
-    def __init__(self, message: str, error_code: str) -> None:
+    def __init__(self, message: str, code: str) -> None:
         super().__init__(message)
-        self.error_code = error_code
+        self.code = code
+


### PR DESCRIPTION
We encounter cases where we try to get_records for an account, but salesforce backend timesout when responding. After trying, we see that we are asking for too much data at once. This PR proposes to shrink the time window if we find a Timeout, hence the amount of data that we get per request.