### PR TITLE
set ensure_ascii=False for json dump

### DIFF
--- a/tap_salesforce/stream.py
+++ b/tap_salesforce/stream.py
@@ -69,6 +69,10 @@ class Stream:
         )
 
     def write_message(self, message: Dict, file: TextIO):
-        line = json.dumps(message, cls=_DatetimeEncoder)
+        line = (
+            json.dumps(message, cls=_DatetimeEncoder, ensure_ascii=False)
+            .encode("utf-8", errors="replace")
+            .decode("utf-8")
+        )
         file.write(line + "\n")
         file.flush()


### PR DESCRIPTION
The fix is for https://dreamdataio.slack.com/archives/C015L6VDSJH/p1670763136953459
made change based on https://stackoverflow.com/questions/40412714/using-json-dumps-with-ensure-ascii-true