### PR TITLE
remove hardcoded custom objects from client

### DIFF
--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -159,51 +159,13 @@ class Salesforce:
             Table(name="OpportunityFieldHistory", replication_key="CreatedDate"),
             Table(name="Product2", replication_key="SystemModstamp"),
             Table(name="OpportunityLineItem", replication_key="SystemModstamp"),
-            Table(name="Revenue_Lifecycle__c", replication_key="SystemModstamp"),
-            Table(
-                name="TrulyActivity__Truly_Activity__c",
-                replication_key="SystemModstamp",
-            ),
             Table(name="Case", replication_key="SystemModstamp", primary_key="Id"),
             Table(
-                name="Task_Milestone__c",
-                replication_key="SystemModstamp",
-                primary_key="Id",
-            ),
-            Table(
-                name="CurrencyType",
+                name="CurrencyType  ",
                 replication_key="SystemModstamp",
                 primary_key="Id",
                 should_sync_fields=True,
-            ),
-            # Custom object for slug: gopigment_com
-            Table(
-                name="Engagement__c",
-                replication_key="SystemModstamp",
-                primary_key="Id",
-                should_sync_fields=True,
-            ),
-            # Custom object for slug: finastra_com
-            Table(
-                name="Opportunity_By_BU__c",
-                replication_key="SystemModstamp",
-                primary_key="Id",
-                should_sync_fields=True,
-            ),
-            # # Custom object for slug: wunderkind_co
-            # Table(
-            #     name="Field_Reports__c",
-            #     replication_key="SystemModstamp",
-            #     primary_key="Id",
-            #     should_sync_fields=True,
-            # ),
-            # Custom object for slug: cognism_com
-            Table(
-                name="Organisation__c",
-                replication_key="SystemModstamp",
-                primary_key="Id",
-                should_sync_fields=True,
-            ),
+            )
         ]
 
         selected_tables = free_tables.copy()


### PR DESCRIPTION
Before merging I'll add these objects in sources postgres in the config column

For these old objects that we can't yet migrate in dataform but we still want to show in the app that they use custom objects I'll have to give a map Id that, nevertheless, will not have an impact on how datamodeling runs (since we don't migrate them yet in dataform). However for some, like finastra, the map Id would have to be something we don't support yet (opportunityID) or for superside and truly activity would have to be Task_Id.

slug: "finastra_com"  -> 

                'Opportunity_By_BU__c' (I'll map to accountId -> Opportunity__c but it should be opportunityId -> Opportunity__c) 

slug: "cognism_com" -> 

             'Organisation__c' (I'll map it to accountId -> Account__c)

slug: "wunderkind_co" -> 

             'Field_Reports__c' (I'll map it to accountId -> Account__c)

slug "gopigment_com" -> 

        'Engagements__c' - used only in the event builder (I'll map it to contactId -> Contact_Name__c)

slug "superside_com" -> 

        'Revenue_Lifecycle__c' (mapped with contacts and leads) (I'll map to ContactId -> Contact__c) and 

         'TrulyActivity__Truly_Activity__c' (mapped with tasks table) (I'll map to ContactId -> Id )

slug "rws_com" -> 

         'Task_Milestone__c' (I'll map to accountId(Account_Id__c))