### PR TITLE
filter square accounts on business unit

### DIFF
--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -296,6 +296,8 @@ class Salesforce:
             where_stm += (
                 f" AND {replication_key} < {end_date.strftime('%Y-%m-%dT%H:%M:%SZ')} "
             )
+            if self.instance_url == "https://squareinc--sqdev.sandbox.my.salesforce.com" and table.name == "Account":
+                where_stm += f" AND Business_Unit__c = 'Afterpay' "
             order_by_stm = f"ORDER BY {replication_key} ASC "
             if primary_key:
                 order_by_stm += f",{primary_key} ASC"


### PR DESCRIPTION
We need to filter also Opportunities, Leads and Contacts but i see that in Contacts the field is called Business_Unit_formula__c , in Opportunities is missing entirely and Leads has no data at all (probably because of sandbox)

<img width="855" alt="Screenshot 2025-02-20 at 16 04 12" src="https://github.com/user-attachments/assets/aa2d7a2c-d273-4f82-bccf-284c5ef3aed2" />
