### PR TITLE
Retry get_records on PrimaryKeyNotMatch error

### DIFF
--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -376,6 +376,13 @@ class Salesforce:
 
             yield merged_record
 
+    @backoff.on_exception(
+        backoff.expo,
+        (PrimaryKeyNotMatch),
+        max_tries=5,
+        factor=2,
+        on_backoff=log_backoff_attempt,
+    )
     def get_records(
         self,
         table: Table,


### PR DESCRIPTION
Added retry for primary key not match error