### PR TITLE
add TapSalesforceReportException and TapSalesforceMissingTablesExcept…

### DIFF
--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -41,6 +41,7 @@ class Table(BaseModel):
     fields: Optional[List[str]]
     should_sync_fields: Optional[bool] = False
     apply_weekly_rule: Optional[bool] = False
+    not_found: Optional[bool] = False
 
     def set_fields(self, fields: List[str]):
         self.fields = fields
@@ -279,9 +280,10 @@ class Salesforce:
                 yield table
             except SalesforceException as e:
                 if e.code == "NOT_FOUND":
-                    LOGGER.info(f"table '{table}' not found, skipping")
-                    continue
-                raise e
+                    table.not_found = True
+                    yield table
+                else:
+                    raise e
 
     def describe(self, table: str) -> Dict:
         try:

--- a/tap_salesforce/exceptions.py
+++ b/tap_salesforce/exceptions.py
@@ -1,7 +1,6 @@
 # pylint: disable=super-init-not-called
-
-
-from typing import Optional
+import json
+from typing import Optional, List, Tuple
 
 import simplejson
 import singer
@@ -29,6 +28,31 @@ class TapSalesforceOauthException(TapSalesforceException):
 
 class TapSalesforceInvalidCredentialsException(TapSalesforceException):
     pass
+
+
+class TapSalesforceMissingTablesException(TapSalesforceException):
+    tables : List[str] = []
+
+    def __init__(self, tables: List[str]) -> None:
+        self.tables = tables
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        return "Missing required tables: " + ", ".join(self.tables)
+
+
+class TapSalesforceReportException(TapSalesforceException):
+    exceptions : List[Exception] = []
+
+    def __init__(self, *exceptions: Exception) -> None:
+        self.exceptions = list(exceptions)
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        return json.dumps([{"type": type(e).__name__, "exception": str(e)} for e in self.exceptions])
+
+    def add(self, exception: Exception) -> None:
+        self.exceptions.append(exception)
 
 
 class SalesforceException(Exception):

--- a/tap_salesforce/exceptions.py
+++ b/tap_salesforce/exceptions.py
@@ -138,13 +138,3 @@ def build_salesforce_exception(resp: Response) -> Optional[SalesforceException]:
         return SalesforceQueryTimeoutException(msg)
 
     return SalesforceException(msg, code)
-
-
-if __name__ == '__main__':
-    x = TapSalesforceMissingTablesException(['a', 'b', 'c'])
-    print(x)
-    y = TapSalesforceReportException(x, ValueError("bad value"))
-    print(y)
-    y.add(KeyError("missing key"))
-    print(y)
-    raise x

--- a/tap_salesforce/exceptions.py
+++ b/tap_salesforce/exceptions.py
@@ -38,7 +38,7 @@ class TapSalesforceMissingTablesException(TapSalesforceException):
         super().__init__(self.__str__())
 
     def __str__(self) -> str:
-        return "Missing required tables: " + ", ".join(self.tables)
+        return "Account is missing access to objects: " + ", ".join(self.tables)
 
 
 class TapSalesforceReportException(TapSalesforceException):
@@ -138,3 +138,13 @@ def build_salesforce_exception(resp: Response) -> Optional[SalesforceException]:
         return SalesforceQueryTimeoutException(msg)
 
     return SalesforceException(msg, code)
+
+
+if __name__ == '__main__':
+    x = TapSalesforceMissingTablesException(['a', 'b', 'c'])
+    print(x)
+    y = TapSalesforceReportException(x, ValueError("bad value"))
+    print(y)
+    y.add(KeyError("missing key"))
+    print(y)
+    raise x


### PR DESCRIPTION
In this PR

* add `TapSalesforceMissingTablesException` and `TapSalesforceReportException` to report missing tables in salesforce sources run

these will allow us to report up when accounts don't have access to objects in salesforce

output for these errors will look like
report with multiple exceptions
```
__main__.TapSalesforceReportException: [{"type": "TapSalesforceMissingTablesException", "exception": "Account is missing access to objects: a, b, c"}, {"type": "ValueError", "exception": "bad value"}, {"type": "KeyError", "exception": "'missing key'"}]
```
single missing tables exception:
```
__main__.TapSalesforceMissingTablesException: Account is missing access to objects: a, b, c
```
