### PR TITLE
merge records on the same id instead of just ordering

### DIFF
--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -395,7 +395,7 @@ class Salesforce:
         pk_field = table.primary_key
         # Bounded buffer: when it reaches this size, yield oldest record
         max_buffer_size = 10000
-        merged_records: OrderedDict[str, Dict] = OrderedDict[str, Dict]()
+        merged_records: OrderedDict[str, Any] = OrderedDict()
 
         # Track active paginators
         active_paginators = list(range(len(paginators)))

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -1,5 +1,6 @@
-from typing import Optional, Dict, List, Iterator
+from typing import Any, Optional, Dict, List, Iterator
 from datetime import datetime, timedelta
+from collections import OrderedDict
 import re
 import backoff
 from pydantic.main import BaseModel
@@ -387,19 +388,46 @@ class Salesforce:
     def merge_records(
         self, paginators: List[Iterator[Dict]], table: Table
     ) -> Iterator[Dict]:
-        for records in zip(*paginators):
-            merged_record = {}
-            primary_key = None
-            for record in records:
-                if not primary_key:
-                    primary_key = record[table.primary_key]
-                if primary_key != record[table.primary_key]:
-                    raise PrimaryKeyNotMatch(
-                        f"couldn't merge records with different primary keys: {primary_key} and {record[table.primary_key]}"
-                    )
-                merged_record.update(record)
+        """
+        Merge records from multiple paginators by primary key.
+        Uses a bounded buffer to limit memory usage.
+        """
+        pk_field = table.primary_key
+        # Bounded buffer: when it reaches this size, yield oldest record
+        max_buffer_size = 10000
+        merged_records: OrderedDict[str, Dict] = OrderedDict[str, Dict]()
 
-            yield merged_record
+        # Track active paginators
+        active_paginators = list(range(len(paginators)))
+
+        while active_paginators:
+            # Process one record from each active paginator
+            for paginator_idx in active_paginators[:]:  # Copy list to allow modification
+                try:
+                    record = next(paginators[paginator_idx])
+                    pk = record[pk_field]
+
+                    # Merge into buffer
+                    if pk not in merged_records:
+                        merged_records[pk] = {}
+                    merged_records[pk].update(record)
+
+                    # Move to end (LRU order)
+                    merged_records.move_to_end(pk)
+
+                except StopIteration:
+                    # This paginator is exhausted
+                    active_paginators.remove(paginator_idx)
+
+            # If buffer is too large, yield oldest record so we are certain that we have merged from all paginators
+            while len(merged_records) > max_buffer_size:
+                pk, record = merged_records.popitem(last=False)  # Remove oldest
+                yield record
+
+        # Yield all remaining records
+        while merged_records:
+            pk, record = merged_records.popitem(last=False)
+            yield record
 
     @backoff.on_exception(
         backoff.expo,


### PR DESCRIPTION
merge_records is used when a Salesforce table has so many fields that the SOQL query would exceed the API’s length limit (~10k characters). In that case, get_records splits the query into several smaller queries (via field_chunker), each returning the same set of records but with different field subsets. Each of those queries is run by a separate paginator (generator from _paginate). merge_records takes that list of paginators and produces a single stream of fully merged records (all fields for each record), so the rest of the tap can consume one record at a time as if there had been a single query.