### PR TITLE
[S-4858] feat(api): add per-customer quotas inline

### DIFF
--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -628,6 +628,7 @@ class Salesforce:
         if match is None:
             return
 
+        used, total = map(int, match.groups())
         self.quota_percent_total = QUOTA_PERCENT_FOR_INSTANCE_URL.get(self.instance_url, DEFAULT_QUOTA_PERCENT_TOTAL)
         self.quota_percent_per_run = QUOTA_PERCENT_FOR_INSTANCE_URL.get(self.instance_url, DEFAULT_QUOTA_PERCENT_PER_RUN)
 

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -166,8 +166,8 @@ class Salesforce:
         refresh_token,
         client_id,
         client_secret,
-        quota_percent_total: DEFAULT_QUOTA_PERCENT_TOTAL,
-        quota_percent_per_run: DEFAULT_QUOTA_PERCENT_PER_RUN,
+        quota_percent_total: float = DEFAULT_QUOTA_PERCENT_TOTAL,
+        quota_percent_per_run: float = DEFAULT_QUOTA_PERCENT_PER_RUN,
         is_sandbox: bool = False,
     ):
         self.refresh_token = refresh_token

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -28,6 +28,13 @@ MAX_QUERY_LENGTH = 10000
 
 LOGGER = singer.get_logger()
 
+QUOTA_PERCENT_FOR_INSTANCE_URL = {
+    "https://pulley.my.salesforce.com": 200.0,
+    "https://maxio.my.salesforce.com": 90.0
+}
+
+DEFAULT_QUOTA_PERCENT_TOTAL = 80.0
+DEFAULT_QUOTA_PERCENT_PER_RUN = 25.0
 
 def log_backoff_attempt(details):
     LOGGER.info(
@@ -159,8 +166,8 @@ class Salesforce:
         refresh_token,
         client_id,
         client_secret,
-        quota_percent_total: float = 80.0,
-        quota_percent_per_run: float = 25.0,
+        quota_percent_total: DEFAULT_QUOTA_PERCENT_TOTAL,
+        quota_percent_per_run: DEFAULT_QUOTA_PERCENT_PER_RUN,
         is_sandbox: bool = False,
     ):
         self.refresh_token = refresh_token
@@ -621,10 +628,8 @@ class Salesforce:
         if match is None:
             return
 
-        if self.instance_url == "https://pulley.my.salesforce.com":
-            return
-
-        used, total = map(int, match.groups())
+        self.quota_percent_total = QUOTA_PERCENT_FOR_INSTANCE_URL.get(self.instance_url, DEFAULT_QUOTA_PERCENT_TOTAL)
+        self.quota_percent_per_run = QUOTA_PERCENT_FOR_INSTANCE_URL.get(self.instance_url, DEFAULT_QUOTA_PERCENT_PER_RUN)
 
         used_percent = (used / total) * 100.0
 


### PR DESCRIPTION
# Description of change

In this change, it's possible to set a per-customer API quota threshold directly in the client. A couple of notes:

- Although we use two different quotas (a per run quota and a total quota), this change only allows setting a single number per customer. I think that's probably fine for now since the general gist is that these customers don't want to have their sync limited.
- I did this because eventually I came to the opinion that persisting this information the credential itself was the wrong thing to do. The credential is a totally separate concept from what is essentially an integration config.
- I also did this because I know the Sources and Destinations team are working on reimplementing. In my view, supporting per-integration config (at least for Salesforce) should be a prerequisite for the new Salesforce source. We can see that there are all sorts of hacks in this client already about tables to avoid, etc... There should be first class support for this in the new integration code.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
