### PR TITLE
Deduplicate legacy objects already in custom_objects config

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -63,9 +63,10 @@ def main_impl():
 
     advanced_features_enabled = args.config.pop("advanced_features_enabled", False)
     custom_objects = args.config.pop("custom_objects", [])
+    special_objects = args.config.pop("special_objects", [])
     missing_tables = []
     try:
-        for table in sf.get_tables(advanced_features_enabled, custom_objects):
+        for table in sf.get_tables(advanced_features_enabled, custom_objects, special_objects):
             if table.not_found:
                 missing_tables.append(table.name)
                 continue

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -266,7 +266,11 @@ class Salesforce:
                 ]
             )
         if self.instance_url in LEGACY_CUSTOMER_OBJECTS:
-            selected_tables.extend(LEGACY_CUSTOMER_OBJECTS[self.instance_url])
+            existing_names = {t.name for t in selected_tables}
+            selected_tables.extend(
+                t for t in LEGACY_CUSTOMER_OBJECTS[self.instance_url]
+                if t.name not in existing_names
+            )
 
         selected_tables.append(
             Table(

--- a/tap_salesforce/client.py
+++ b/tap_salesforce/client.py
@@ -189,7 +189,7 @@ class Salesforce:
         self._login()
 
     def get_tables(
-        self, advanced_features_enabled=False, custom_objects=[]
+        self, advanced_features_enabled=False, custom_objects=[], special_objects=[]
     ) -> Iterator[Table]:
         """returns the supported table names, as well as the replication_key"""
         free_tables = [
@@ -265,7 +265,16 @@ class Salesforce:
                     for custom_object in custom_objects
                 ]
             )
-        if self.instance_url in LEGACY_CUSTOMER_OBJECTS:
+        if special_objects:
+            LOGGER.info("special objects enabled for account")
+            existing_names = {t.name for t in selected_tables}
+            selected_tables.extend(
+                [
+                    Table(**obj) for obj in special_objects
+                    if obj.get("name") not in existing_names
+                ]
+            )
+        elif self.instance_url in LEGACY_CUSTOMER_OBJECTS:
             existing_names = {t.name for t in selected_tables}
             selected_tables.extend(
                 t for t in LEGACY_CUSTOMER_OBJECTS[self.instance_url]


### PR DESCRIPTION
Skip LEGACY_CUSTOMER_OBJECTS entries when the object is already in the selected tables list (e.g., added via custom_objects config). Prevents duplicate syncs and wasted API quota when migrating legacy per-instance objects into the custom_objects config.
